### PR TITLE
use PreparedStatement

### DIFF
--- a/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaOutputFormat.java
+++ b/src/contrib/vertica/src/java/org/apache/hadoop/vertica/VerticaOutputFormat.java
@@ -207,10 +207,12 @@ public class VerticaOutputFormat extends OutputFormat<Text, VerticaRecord> {
       // poll for refresh complete
       boolean refreshing = true;
       Long timeout = vtconfig.getOptimizePollTimeout();
+	  PreparedStatement prepareStmt = conn.prepareStatement("select table_name, status from vt_projection_refresh");
       while (refreshing) {
         refreshing = false;
-        rs = stmt
-            .executeQuery("select table_name, status from vt_projection_refresh");
+        //rs = stmt
+        //    .executeQuery("select table_name, status from vt_projection_refresh");
+		rs = prepareStmt.executeQuery();
         while (rs.next()) {
           String table = rs.getString(1);
           String stat = rs.getString(2);


### PR DESCRIPTION
Hello,
Is it a good way to use PreparedStatement in line 212 and 213? Because the "executeQuery" is in a while loop and the query is compiled only once when we use "PreparedStatement" interface which can improve the performance of the application.